### PR TITLE
t/parent.t - Harden test against possible wording change

### DIFF
--- a/t/parent.t
+++ b/t/parent.t
@@ -48,8 +48,8 @@ is( $Eval1::VERSION, '1.01' );
 
 is( $Eval2::VERSION, '1.02' );
 
-my $expected= q{/^Can't locate reallyReAlLyNotexists.pm in \@INC \(\@INC contains:/};
-$expected= q{/^Can't locate reallyReAlLyNotexists.pm in \@INC \(you may need to install the reallyReAlLyNotexists module\) \(\@INC contains:/}
+my $expected= q{/^Can't locate reallyReAlLyNotexists.pm in \@INC \(\@INC[\w ]+:/};
+$expected= q{/^Can't locate reallyReAlLyNotexists.pm in \@INC \(you may need to install the reallyReAlLyNotexists module\) \(\@INC[\w ]+:/}
     if 5.017005 <= $];
 
 eval q{use parent::versioned 'reallyReAlLyNotexists'};
@@ -66,4 +66,3 @@ like( $@, $expected, '  still failing on 2nd load');
     use parent::versioned -norequire, 'Has::Version_0';
     ::is( $Has::Version_0::VERSION, 0, '$VERSION==0 preserved' );
 }
-


### PR DESCRIPTION
In https://github.com/Perl/perl5/pull/20547 we changed the error message from failed requires to be more appropriate. This patch hardens the tests so that whatever wording is chosen will be accepted without error, and so the tests can run on whatever perl is used.

Eg, in the future perl may say "@INC entries checked:" instead of "@INC contains:", as we will start reporting what was actually done instead of the state of @INC at the end of the require. The two may not be even remotely the same. This patch ensures that whatever wording is used after the @INC and before the ":" we will pass test.

Note this is the same patch that was applied to parent in https://github.com/Corion/parent/pull/12 

See also https://github.com/Perl/perl5/issues/20651